### PR TITLE
Добавлено подключение к базе данных PostgreSQL через Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+
+services:
+  postgres:
+    image: postgres:13
+    container_name: postgres-db
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: user_service_db
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - user_service_network
+
+volumes:
+  postgres-data:
+
+networks:
+  user_service_network:
+    driver: bridge

--- a/homework_3/src/main/resources/hibernate.cfg.xml
+++ b/homework_3/src/main/resources/hibernate.cfg.xml
@@ -5,14 +5,16 @@
 <hibernate-configuration>
     <session-factory>
         <property name="hibernate.connection.driver_class">org.postgresql.Driver</property>
-        <property name="hibernate.connection.url">jdbc:postgresql://localhost:5432/user_db</property>
-        <property name="hibernate.connection.username">postgres</property>
+        <property name="hibernate.connection.url">jdbc:postgresql://localhost:5433/user_service_db</property>
+        <property name="hibernate.connection.username">user</property>
         <property name="hibernate.connection.password">password</property>
         <property name="hibernate.connection.pool_size">5</property>
         <property name="hibernate.dialect">org.hibernate.dialect.PostgreSQLDialect</property>
         <property name="hibernate.show_sql">true</property>
         <property name="hibernate.format_sql">true</property>
-        <property name="hibernate.hbm2ddl.auto">update</property>
+        <property name="hibernate.use_sql_comments">true</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+        <property name="hibernate.jdbc.lob.non_contextual_creation">true</property>
         <mapping class="ru.aston.teamwork.entity.User"/>
     </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
- Настроен контейнер PostgreSQL в Docker с использованием образа postgres:13
- Указан порт 5433 для подключения к БД (замена стандартного порта 5432)
- Создана база данных `user_service_db` в контейнере